### PR TITLE
Fix markdown formatting in project modal

### DIFF
--- a/app.js
+++ b/app.js
@@ -676,7 +676,7 @@ document.addEventListener('DOMContentLoaded', () => {
         // --- 4. Populate Main Description ---
         let descriptionHTML = '';
         if (item.long_description) {
-            descriptionHTML = `<p>${item.long_description.replace(/\n/g, '</p><p>')}</p>`;
+            descriptionHTML = marked.parse(item.long_description);
         } else if (item.problem_statement) {
             descriptionHTML = `
                 <h4 class="font-semibold text-slate-800">The Challenge</h4>


### PR DESCRIPTION
The project modal was displaying raw markdown syntax (e.g., `**text**`) because it was using a simple regex replacement to handle newlines instead of a proper markdown parser. This change updates the `populateModal` function in `app.js` to use `marked.parse(item.long_description)`, ensuring that bold text, lists, and other markdown features are rendered correctly.
Verified the fix by creating a Playwright script that opened the modal and confirmed that the markdown was parsed into HTML elements (e.g., `<strong>`, `<li>`).

---
*PR created automatically by Jules for task [13319640636900833044](https://jules.google.com/task/13319640636900833044) started by @Qamar2315*