### PR TITLE
Fix Markdown rendering in project modals

### DIFF
--- a/app.js
+++ b/app.js
@@ -676,13 +676,13 @@ document.addEventListener('DOMContentLoaded', () => {
         // --- 4. Populate Main Description ---
         let descriptionHTML = '';
         if (item.long_description) {
-            descriptionHTML = `<p>${item.long_description.replace(/\n/g, '</p><p>')}</p>`;
+            descriptionHTML = marked.parse(item.long_description);
         } else if (item.problem_statement) {
             descriptionHTML = `
                 <h4 class="font-semibold text-slate-800">The Challenge</h4>
-                <p class="mb-4">${item.problem_statement}</p>
+                <div class="mb-4">${marked.parse(item.problem_statement)}</div>
                 <h4 class="font-semibold text-slate-800">My Solution</h4>
-                <p>${item.solution_delivered}</p>
+                <div>${marked.parse(item.solution_delivered)}</div>
             `;
         }
         modalMainDescription.innerHTML = descriptionHTML;


### PR DESCRIPTION
This PR fixes an issue where Markdown syntax (specifically bold text using `**`) was being displayed as raw text in project modal descriptions. 

Changes:
- Updated `populateModal` function in `app.js` to use `marked.parse()` for rendering `long_description`, `problem_statement`, and `solution_delivered`.
- Changed the wrapping HTML elements for `problem_statement` and `solution_delivered` from `<p>` to `<div>` to prevent invalid HTML nesting when `marked` generates block-level elements like `<p>` or `<ul>`.

Verification:
- Manually verified using a Playwright script that asserts the presence of rendered HTML (e.g., `<strong>`) and the absence of raw Markdown syntax in the modal content.
- Visually confirmed via screenshot that the text is correctly formatted.

---
*PR created automatically by Jules for task [11419219910650684976](https://jules.google.com/task/11419219910650684976) started by @Qamar2315*