### PR TITLE
Fix frontend bugs and upgrade to Tailwind v3

### DIFF
--- a/app.js
+++ b/app.js
@@ -297,7 +297,7 @@ document.addEventListener('DOMContentLoaded', () => {
             resumeDownload.addEventListener('click', async function(e) {
                 e.preventDefault();
                 try {
-                    const response = await fetch(`/${personalInfo.resume_file}`);
+                    const response = await fetch(personalInfo.resume_file);
                     const blob = await response.blob();
                     const url = window.URL.createObjectURL(blob);
                     const link = document.createElement('a');
@@ -310,7 +310,7 @@ document.addEventListener('DOMContentLoaded', () => {
                 } catch (error) {
                     console.error('Download failed:', error);
                     // Fallback: open in new tab
-                    window.open(`/${personalInfo.resume_file}`, '_blank');
+                    window.open(personalInfo.resume_file, '_blank');
                 }
             });
         }
@@ -723,9 +723,11 @@ document.addEventListener('DOMContentLoaded', () => {
         // --- 8. Populate Technologies ---
         if (item.technologies && item.technologies.length > 0) {
             modalTechBlock.classList.remove('hidden');
-            const techColor = item.problem_statement ? 'green' : 'blue'; // Green for freelance, blue for personal
+            const isFreelance = item.problem_statement ? true : false;
+            const bgClass = isFreelance ? 'bg-green-100' : 'bg-blue-100';
+            const textClass = isFreelance ? 'text-green-800' : 'text-blue-800';
             modalTechList.innerHTML = item.technologies.map(tech =>
-                `<span class="bg-${techColor}-100 text-${techColor}-800 text-sm font-medium px-2.5 py-1 rounded-full">${tech}</span>`
+                `<span class="${bgClass} ${textClass} text-sm font-medium px-2.5 py-1 rounded-full">${tech}</span>`
             ).join('');
         }
 

--- a/index.html
+++ b/index.html
@@ -5,7 +5,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Qamar Ul Islam - Software Engineer</title>
-    <link href="https://cdn.jsdelivr.net/npm/tailwindcss@2.2.19/dist/tailwind.min.css" rel="stylesheet" />
+    <script src="https://cdn.tailwindcss.com?plugins=typography"></script>
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css"
         integrity="sha512-iecdLmaskl7CVkqkXNQ/ZH/XLlvWZOJyj7Yy7tcenmpD1ypASozpmT/E0iPtmFIB46ZmdtAc9eNBvH0H/ZpiBw=="
         crossorigin="anonymous" referrerpolicy="no-referrer" />


### PR DESCRIPTION
I have identified and resolved several flaws in the portfolio site:
1. **Missing Tailwind Classes:** The site was using an outdated Tailwind v2 CDN link, causing newer utility classes (like `slate` colors) to not render correctly. I've updated it to the Tailwind v3 Play CDN, along with the `typography` plugin for markdown rendering.
2. **Pathing Issues:** The fetch call to download the resume in `app.js` used an absolute root path (`/resume.pdf`). I updated this to be a relative path, which is safer when hosting the site on platforms like GitHub Pages that may use subdirectories.
3. **Dynamic Tailwind Strings:** In `app.js`, pill tags were constructing class names dynamically (`bg-${techColor}-100`). The Tailwind JIT compiler cannot detect these, causing the tags to miss their styles. I've updated this code to use explicit full string literals instead.
4. Cleaned up all temporary testing files and verification screenshots.

---
*PR created automatically by Jules for task [12279047675149212734](https://jules.google.com/task/12279047675149212734) started by @Qamar2315*