### PR TITLE
Fix markdown parsing for lists and bold formatting in modal

### DIFF
--- a/app.js
+++ b/app.js
@@ -686,7 +686,7 @@ document.addEventListener('DOMContentLoaded', () => {
         // --- 4. Populate Main Description ---
         let descriptionHTML = '';
         if (item.long_description) {
-            descriptionHTML = marked.parse(item.long_description);
+            descriptionHTML = marked.parse(item.long_description.replace(/\\n/g, '\n'));
         } else if (item.problem_statement) {
             descriptionHTML = `
                 <h4 class="font-semibold text-slate-800">The Challenge</h4>


### PR DESCRIPTION
This submission fixes the issue where markdown formatting, such as bold text (`**`) and numbered lists (`1. `), were not correctly rendered in project and experience modals, showing up as raw asterisks instead.

**Changes:**
- Updated `app.js` line 689 to include `.replace(/\\n/g, '\n')` before passing the `long_description` to `marked.parse()`.
- Verified the fix via Playwright UI verification with screenshots and videos.

---
*PR created automatically by Jules for task [3433462235171123300](https://jules.google.com/task/3433462235171123300) started by @Qamar2315*