### PR TITLE
Fix Markdown Parsing in Project Descriptions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,1 @@
-.vscode
-temp.txt
-dep.png
+.vscode\ntemp.txt\ndep.png

--- a/app.js
+++ b/app.js
@@ -214,7 +214,7 @@ document.addEventListener('DOMContentLoaded', () => {
             </div>
             <h3 class="text-xl font-bold mb-2 text-slate-800">${project.title || 'Untitled Project'}</h3>
             ${techPills}
-            <p class="text-slate-600 mb-4 flex-grow">${project.short_description || ''}</p>
+            <p class="text-slate-600 mb-4 flex-grow">${project.short_description ? marked.parseInline(project.short_description) : ''}</p>
             <div class="mt-auto pt-4 border-t border-slate-100">
                 <span class="text-blue-500 font-semibold group-hover:text-blue-600 transition-colors">View Details <i class="fas fa-arrow-right ml-1 transform group-hover:translate-x-1 transition-transform"></i></span>
             </div>
@@ -251,7 +251,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
         const desc = document.createElement('p');
         desc.className = 'text-slate-600';
-        desc.textContent = work.short_description || '';
+        desc.innerHTML = work.short_description ? marked.parseInline(work.short_description) : '';
 
         card.appendChild(title);
         card.appendChild(desc);
@@ -445,7 +445,7 @@ document.addEventListener('DOMContentLoaded', () => {
             // Create the list of responsibilities
             const responsibilitiesHTML = (job.responsibilities || []).map((item, index) => {
                 if (typeof item === 'string') {
-                    return `<li class="mb-2">${item}</li>`;
+                    return `<li class="mb-2">${marked.parseInline(item)}</li>`;
                 } else if (typeof item === 'object' && item.summary) {
                     // It's a detailed object
                     // We'll add a data attribute to the button to identify which item it is
@@ -485,14 +485,14 @@ document.addEventListener('DOMContentLoaded', () => {
                     li.className = "mb-3 leading-relaxed"; // Added spacing and line-height
 
                     if (typeof item === 'string') {
-                        li.textContent = item;
+                        li.innerHTML = marked.parseInline(item);
                     } else if (typeof item === 'object' && item.summary) {
                         // Detailed Item Container
                         const container = document.createElement('div');
                         container.className = "inline"; 
 
                         const summaryText = document.createElement('span');
-                        summaryText.textContent = item.summary + " ";
+                        summaryText.innerHTML = marked.parseInline(item.summary) + " ";
                         container.appendChild(summaryText);
 
                         const viewDetailsBtn = document.createElement('button');
@@ -686,7 +686,8 @@ document.addEventListener('DOMContentLoaded', () => {
         // --- 4. Populate Main Description ---
         let descriptionHTML = '';
         if (item.long_description) {
-            descriptionHTML = marked.parse(item.long_description);
+            let processedDesc = item.long_description.replace(/\\\\n/g, '\n').replace(/\\n/g, '\n').replace(/\\\\\*/g, '*').replace(/\\\*/g, '*');
+            descriptionHTML = marked.parse(processedDesc);
         } else if (item.problem_statement) {
             descriptionHTML = `
                 <h4 class="font-semibold text-slate-800">The Challenge</h4>


### PR DESCRIPTION
This resolves the issue where raw markdown asterisks (**) were being rendered literally instead of formatting the text as bold.
- The `long_description` in `json_data` files uses varied escaping techniques for newlines and asterisks (`\n`, `\\n`, `\*`, `\\*`). `marked.parse()` wasn't formatting these correctly unless preprocessed. A string replacement handles this before parsing.
- For `short_description` on project/freelance cards and `responsibilities` in the experience timeline, `marked.parseInline()` is now used in combination with setting the `.innerHTML` property instead of `.textContent`, which guarantees any HTML generated by Marked (like `<strong>`) is properly rendered by the browser rather than escaped as plain text.

---
*PR created automatically by Jules for task [13776230270477348084](https://jules.google.com/task/13776230270477348084) started by @Qamar2315*