### PR TITLE
Fix Chat Input Field Outline

### DIFF
--- a/index.html
+++ b/index.html
@@ -801,7 +801,7 @@
             <div class="p-4 border-t border-slate-200 bg-slate-50 rounded-b-2xl">
                 <form id="chat-form" class="flex items-center bg-white border border-slate-300 rounded-full focus-within:ring-2 focus-within:ring-blue-500">
                     <!-- *** THE FIX IS HERE: flex-1 instead of w-full *** -->
-                    <input type="text" id="chat-input" placeholder="e.g., Tell me about your AI projects..." class="flex-1 bg-transparent px-5 py-3 border-none focus:ring-0 text-slate-800 placeholder-slate-400">
+                    <input type="text" id="chat-input" placeholder="e.g., Tell me about your AI projects..." class="flex-1 bg-transparent px-5 py-3 border-none focus:outline-none focus:ring-0 text-slate-800 placeholder-slate-400">
                     <button id="chat-send" type="submit" class="p-2 text-white bg-blue-500 hover:bg-blue-600 rounded-full m-1.5 transition-colors disabled:bg-slate-300 disabled:cursor-not-allowed">
                         <svg class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 19l9 2-9-18-9 18 9-2zm0 0v-8"></path></svg>
                     </button>


### PR DESCRIPTION
Added the `focus:outline-none` Tailwind utility class to the `#chat-input` element in `index.html`. This removes the default black rectangular browser outline that appears upon focus, ensuring only the intended blue Tailwind ring from the parent form element is visible. This improves the visual appearance of the chatbot's input field.

---
*PR created automatically by Jules for task [12101238240134594180](https://jules.google.com/task/12101238240134594180) started by @Qamar2315*