### PR TITLE
Fix markdown asterisks rendering in short descriptions and lists

### DIFF
--- a/app.js
+++ b/app.js
@@ -214,7 +214,7 @@ document.addEventListener('DOMContentLoaded', () => {
             </div>
             <h3 class="text-xl font-bold mb-2 text-slate-800">${project.title || 'Untitled Project'}</h3>
             ${techPills}
-            <p class="text-slate-600 mb-4 flex-grow">${project.short_description || ''}</p>
+            <p class="text-slate-600 mb-4 flex-grow">${marked.parseInline(project.short_description || '')}</p>
             <div class="mt-auto pt-4 border-t border-slate-100">
                 <span class="text-blue-500 font-semibold group-hover:text-blue-600 transition-colors">View Details <i class="fas fa-arrow-right ml-1 transform group-hover:translate-x-1 transition-transform"></i></span>
             </div>
@@ -251,7 +251,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
         const desc = document.createElement('p');
         desc.className = 'text-slate-600';
-        desc.textContent = work.short_description || '';
+        desc.innerHTML = marked.parseInline(work.short_description || '');
 
         card.appendChild(title);
         card.appendChild(desc);
@@ -485,14 +485,14 @@ document.addEventListener('DOMContentLoaded', () => {
                     li.className = "mb-3 leading-relaxed"; // Added spacing and line-height
 
                     if (typeof item === 'string') {
-                        li.textContent = item;
+                        li.innerHTML = marked.parseInline(item);
                     } else if (typeof item === 'object' && item.summary) {
                         // Detailed Item Container
                         const container = document.createElement('div');
                         container.className = "inline"; 
 
                         const summaryText = document.createElement('span');
-                        summaryText.textContent = item.summary + " ";
+                        summaryText.innerHTML = marked.parseInline(item.summary) + " ";
                         container.appendChild(summaryText);
 
                         const viewDetailsBtn = document.createElement('button');


### PR DESCRIPTION
This pull request fixes an issue where literal asterisks (e.g. `**text**`) were being displayed as plain text instead of rendering as bold text in project, experience, and freelance descriptions.\n\nThe `app.js` file was updated to use `marked.parseInline()` when setting the content of these fields, replacing `textContent` with `innerHTML` to ensure the generated HTML tags are applied.

---
*PR created automatically by Jules for task [10455008868643595491](https://jules.google.com/task/10455008868643595491) started by @Qamar2315*