### PR TITLE
Fix markdown bold text rendering in lists

### DIFF
--- a/json_data/experience.json
+++ b/json_data/experience.json
@@ -11,7 +11,7 @@
           "title": "Autonomous Lead Generation AI",
           "role": "Lead Python Automation Engineer",
           "short_description": "A modular AI system for autonomous lead discovery, verification, and CRM injection.",
-          "long_description": "Developed a modular Autonomous Lead Generation AI on a Linux VPS. The system integrates multi-source scraping (Google Maps, Yelp), AI-based verification using GPT-5 Nano (or GPT-4o-mini), and automated enrichment via Apollo.io to push high-quality, verified leads directly into Zoho CRM.\\n\\nKey capabilities include:\\n1. **Multi-Source Scraping:** Aggregates leads from Google Maps and Yelp.\\n2. **AI Verification:** Uses LLMs to verify lead relevance and quality.\\n3. **CRM Integration:** Direct sync to Zoho CRM for sales team action.",
+          "long_description": "Developed a modular Autonomous Lead Generation AI on a Linux VPS. The system integrates multi-source scraping (Google Maps, Yelp), AI-based verification using GPT-5 Nano (or GPT-4o-mini), and automated enrichment via Apollo.io to push high-quality, verified leads directly into Zoho CRM.\\n\\nKey capabilities include:\\n\\n1. **Multi-Source Scraping:** Aggregates leads from Google Maps and Yelp.\\n2. **AI Verification:** Uses LLMs to verify lead relevance and quality.\\n3. **CRM Integration:** Direct sync to Zoho CRM for sales team action.",
           "key_features": [
             "Multi-Source Scraping (Google Maps, Yelp)",
             "AI-Based Lead Verification (GPT-5 Nano)",
@@ -42,7 +42,7 @@
           "title": "Intelligent Invoice Processing Automation",
           "role": "Automation Architect",
           "short_description": "End-to-end invoice automation workflow using n8n and Generative AI.",
-          "long_description": "Architected and deployed an intelligent invoice processing system using n8n and Google Gemini. The solution automates data extraction from unstructured PDF and image invoices received via Gmail, parses them using GenAI, and syncs structured financial records to Airtable for real-time approval workflows.\\n\\nKey capabilities include:\\n1. **AI-Powered Extraction:** Uses Gemini to parse complex invoice layouts.\\n2. **Seamless Integrations:** Connects Gmail, Drive, and Airtable via n8n.\\n3. **Human-in-the-Loop:** Airtable powered approval flows.",
+          "long_description": "Architected and deployed an intelligent invoice processing system using n8n and Google Gemini. The solution automates data extraction from unstructured PDF and image invoices received via Gmail, parses them using GenAI, and syncs structured financial records to Airtable for real-time approval workflows.\\n\\nKey capabilities include:\\n\\n1. **AI-Powered Extraction:** Uses Gemini to parse complex invoice layouts.\\n2. **Seamless Integrations:** Connects Gmail, Drive, and Airtable via n8n.\\n3. **Human-in-the-Loop:** Airtable powered approval flows.",
           "key_features": [
             "AI Data Extraction (Google Gemini)",
             "Automated Workflow Orchestration (n8n)",
@@ -166,7 +166,7 @@
           "title": "Vapi Transfer — AI Contact Center",
           "role": "Lead VOIP & Full-Stack Engineer",
           "short_description": "Real-time AI-to-Human call handoff platform using FreeSWITCH and WebRTC.",
-          "long_description": "Designed, developed, and deployed a production-grade AI-powered contact center platform enabling seamless real-time call transfer between Vapi AI voice assistants and live human agents. The system supports AI-first outbound calling, live agent monitoring, barge-in/takeover capabilities, and intelligent call routing through a WebRTC-based agent dashboard.\\n\\nCore components:\\n1. **FreeSWITCH SIP/WebRTC Platform:** Dockerized cluster handling NAT traversal and RTP.\\n2. **AI-to-Human Handoff:** Custom dialplans for smooth transfer.\\n3. **WebRTC Agent Dashboard:** React-based interface for real-time call controls (Barge-in, Monitor).",
+          "long_description": "Designed, developed, and deployed a production-grade AI-powered contact center platform enabling seamless real-time call transfer between Vapi AI voice assistants and live human agents. The system supports AI-first outbound calling, live agent monitoring, barge-in/takeover capabilities, and intelligent call routing through a WebRTC-based agent dashboard.\\n\\nCore components:\\n\\n1. **FreeSWITCH SIP/WebRTC Platform:** Dockerized cluster handling NAT traversal and RTP.\\n2. **AI-to-Human Handoff:** Custom dialplans for smooth transfer.\\n3. **WebRTC Agent Dashboard:** React-based interface for real-time call controls (Barge-in, Monitor).",
           "key_features": [
             "AI-to-Human Call Handoff",
             "WebRTC Agent Dashboard (React)",

--- a/json_data/projects.json
+++ b/json_data/projects.json
@@ -1,13 +1,13 @@
 [
   {
     "id": "clean-md-to-multi-format",
-    "title": "Clean MD to Multi-Format — VS Code Extension",
+    "title": "Clean MD to Multi-Format \u2014 VS Code Extension",
     "project_type": "Personal Project",
     "status": "Live",
     "role": "Creator & Lead Developer",
     "date_range": "2024 - Present",
     "short_description": "Developed and published a feature-rich VS Code Extension that converts Markdown files into professional, publication-ready documents (PDF, HTML, DOCX) with advanced theming.",
-    "long_description": "Developed and published a feature-rich VS Code Extension that converts Markdown files into professional, publication-ready documents. The extension prioritizes clean, watermark-free output and offers advanced theming options for various use cases (Academic, Corporate, Tech).\n\nKey capabilities include:\n1. **Multi-Format Conversion Engine:** Engineered a conversion pipeline using markdown-it and Puppeteer (headless Chrome) for high-fidelity PDF rendering, with adapters for HTML and DOCX export.\n2. **Advanced Theming System:** Created 10 professional CSS-based themes that dynamically inject styling into the rendering pipeline, supporting syntax highlighting and complex layouts.\n3. **VS Code Integration:** Deeply integrated with the VS Code API for command palette commands, context menu actions, and reactive configuration settings.",
+    "long_description": "Developed and published a feature-rich VS Code Extension that converts Markdown files into professional, publication-ready documents. The extension prioritizes clean, watermark-free output and offers advanced theming options for various use cases (Academic, Corporate, Tech).\n\nKey capabilities include:\n\n1. **Multi-Format Conversion Engine:** Engineered a conversion pipeline using markdown-it and Puppeteer (headless Chrome) for high-fidelity PDF rendering, with adapters for HTML and DOCX export.\n2. **Advanced Theming System:** Created 10 professional CSS-based themes that dynamically inject styling into the rendering pipeline, supporting syntax highlighting and complex layouts.\n3. **VS Code Integration:** Deeply integrated with the VS Code API for command palette commands, context menu actions, and reactive configuration settings.",
     "key_features": [
       "Convert Markdown to PDF, HTML, DOCX",
       "High-fidelity rendering with Puppeteer",
@@ -46,13 +46,13 @@
   },
   {
     "id": "color-by-numb3r",
-    "title": "Color by Numb3r — Full-Stack E-Commerce & Content Platform",
+    "title": "Color by Numb3r \u2014 Full-Stack E-Commerce & Content Platform",
     "project_type": "Freelance Project",
     "status": "Live",
     "role": "Lead Full-Stack Architect",
     "date_range": "2024 - Present",
     "short_description": "Architected and deployed a multi-tenant e-commerce and content platform for a creative business, featuring a custom React CMS, automated product syncing, and a robust FastAPI backend.",
-    "long_description": "Architected and deployed a comprehensive e-commerce and content management platform for a niche creative business. The system features a multi-tenant architecture serving three distinct user groups: Customers (Storefront), Designers (Creative Tools), and Admins (Management).\n\nKey capabilities include:\n1. **High-Performance Infrastructure:** Hosted on a custom Linux VPS with Nginx reverse proxy and fully automated CI/CD via GitHub Actions.\n2. **Advanced Backend Engineering:** Powered by FastAPI and MongoDB (Beanie), featuring an automated background sync engine that aggregates products from external marketplaces (Bol.com) and a ScrapingAnt service to bypass anti-bot protections.\n3. **Modular Frontend:** A complex React 19 SPA with distinct layouts for Public, Admin, and Designer portals, plus a bespoke CMS with rich-text editing and Cloudinary image optimization.",
+    "long_description": "Architected and deployed a comprehensive e-commerce and content management platform for a niche creative business. The system features a multi-tenant architecture serving three distinct user groups: Customers (Storefront), Designers (Creative Tools), and Admins (Management).\n\nKey capabilities include:\n\n1. **High-Performance Infrastructure:** Hosted on a custom Linux VPS with Nginx reverse proxy and fully automated CI/CD via GitHub Actions.\n2. **Advanced Backend Engineering:** Powered by FastAPI and MongoDB (Beanie), featuring an automated background sync engine that aggregates products from external marketplaces (Bol.com) and a ScrapingAnt service to bypass anti-bot protections.\n3. **Modular Frontend:** A complex React 19 SPA with distinct layouts for Public, Admin, and Designer portals, plus a bespoke CMS with rich-text editing and Cloudinary image optimization.",
     "key_features": [
       "Multi-Tenant Architecture (Customer, Designer, Admin)",
       "Automated External Product Sync (Bol.com) with ScrapingAnt",
@@ -112,7 +112,7 @@
     "role": "Lead Python Automation Engineer",
     "date_range": "2024",
     "short_description": "Developed a proprietary, modular Python application designed to autonomously identify, verify, and qualify real estate leads, fully integrated with the Zoho Ecosystem.",
-    "long_description": "Developed a proprietary, modular Python application designed to autonomously identify, verify, and qualify real estate leads (Residential, Commercial, Hospitality). The system is deployed on a Virtual Private Server (VPS) and runs on a strict weekly schedule to ensure a continuous pipeline of high-quality leads.\n\nKey capabilities include:\n1. **High-Availability Infrastructure:** Hosted on a Linux VPS for performance, executing complex scraping and AI tasks without local resource constraints, with orchestration via Zoho.\n2. **5-Stage Data Pipeline:** Engineered robust scrapers (ALN, Crexi, Yelp, Google Maps) with rotation logic, followed by a normalization engine to unify data structures.\n3. **AI Verification & Enrichment:** Integrated OpenAI (GPT-5 Nano) to verify facility services from property websites and utilized Apollo.io/RocketReach to retrieve and validate decision-maker contact info.\n4. **Scoring & Routing:** Implemented a logic-based scoring engine (0-100) to route high-confidence leads (>75) directly to Zoho CRM via OAuth 2.0.",
+    "long_description": "Developed a proprietary, modular Python application designed to autonomously identify, verify, and qualify real estate leads (Residential, Commercial, Hospitality). The system is deployed on a Virtual Private Server (VPS) and runs on a strict weekly schedule to ensure a continuous pipeline of high-quality leads.\n\nKey capabilities include:\n\n1. **High-Availability Infrastructure:** Hosted on a Linux VPS for performance, executing complex scraping and AI tasks without local resource constraints, with orchestration via Zoho.\n2. **5-Stage Data Pipeline:** Engineered robust scrapers (ALN, Crexi, Yelp, Google Maps) with rotation logic, followed by a normalization engine to unify data structures.\n3. **AI Verification & Enrichment:** Integrated OpenAI (GPT-5 Nano) to verify facility services from property websites and utilized Apollo.io/RocketReach to retrieve and validate decision-maker contact info.\n4. **Scoring & Routing:** Implemented a logic-based scoring engine (0-100) to route high-confidence leads (>75) directly to Zoho CRM via OAuth 2.0.",
     "key_features": [
       "Multi-Source Extraction (ALN, Crexi, Yelp, Google Maps)",
       "AI Service Verification using OpenAI GPT-5 Nano",
@@ -165,7 +165,7 @@
     "role": "Automation Architect & Developer",
     "date_range": "2024",
     "short_description": "Architected and deployed a sophisticated low-code/code-full workflow using n8n to automate financial operations, bridging Gmail and Airtable with Generative AI for invoice parsing.",
-    "long_description": "Architected and deployed a sophisticated low-code/code-full workflow using n8n to automate financial operations. The system serves as a bridge between communication channels (Gmail) and database systems (Airtable), utilizing Generative AI to parse unstructured invoice data into structured financial records.\n\nKey capabilities include:\n1. **Event-Driven Architecture:** Configured webhooks and triggers within n8n to monitor Gmail in real-time for specific invoice attachments or subject line patterns.\n2. **AI Data Extraction:** Integrated Google’s Gemini LLM via API to act as an intelligent parser. The AI agent analyzes PDF/Image invoices, extracting key fields (Invoice ID, Line Items, Tax, Vendor Details) regardless of the document layout, replacing rigid OCR templates.\n3. **Cloud Sync & Management:** Automated file handling to archive raw documents into structured Google Drive directories and orchestrated record creation in Airtable for finance team approval.",
+    "long_description": "Architected and deployed a sophisticated low-code/code-full workflow using n8n to automate financial operations. The system serves as a bridge between communication channels (Gmail) and database systems (Airtable), utilizing Generative AI to parse unstructured invoice data into structured financial records.\n\nKey capabilities include:\n\n1. **Event-Driven Architecture:** Configured webhooks and triggers within n8n to monitor Gmail in real-time for specific invoice attachments or subject line patterns.\n2. **AI Data Extraction:** Integrated Google\u2019s Gemini LLM via API to act as an intelligent parser. The AI agent analyzes PDF/Image invoices, extracting key fields (Invoice ID, Line Items, Tax, Vendor Details) regardless of the document layout, replacing rigid OCR templates.\n3. **Cloud Sync & Management:** Automated file handling to archive raw documents into structured Google Drive directories and orchestrated record creation in Airtable for finance team approval.",
     "key_features": [
       "Event-Driven Architecture with n8n webhooks",
       "Real-time Gmail monitoring for invoices",
@@ -660,7 +660,7 @@
     "key_challenges": [
       {
         "challenge": "Building a Type-Safe Full-Stack Application",
-        "solution": "Leveraged TypeScript across the entire stack—for the Angular frontend and the Node.js/Express backend. This created an end-to-end type-safe environment, significantly reducing runtime errors, improving developer experience, and making the API contract between the client and server more robust and self-documenting."
+        "solution": "Leveraged TypeScript across the entire stack\u2014for the Angular frontend and the Node.js/Express backend. This created an end-to-end type-safe environment, significantly reducing runtime errors, improving developer experience, and making the API contract between the client and server more robust and self-documenting."
       },
       {
         "challenge": "Managing Application State and Reactivity",


### PR DESCRIPTION
Fix markdown bold text rendering in lists

Lists embedded within JSON data strings (e.g., `long_description`) must be preceded by a double newline (`\n\n` or `\\n\\n`) to ensure the `marked` library correctly parses them as lists rather than inline text. This commit fixes occurrences of `include:\n1.` to be `include:\n\n1.` in `projects.json` and `experience.json`, which resolves an issue where bold texts with asterisks were rendered as literals.

---
*PR created automatically by Jules for task [13276001255200592864](https://jules.google.com/task/13276001255200592864) started by @Qamar2315*