### PR TITLE
Fix markdown list parsing in long_description

### DIFF
--- a/app.js
+++ b/app.js
@@ -686,7 +686,7 @@ document.addEventListener('DOMContentLoaded', () => {
         // --- 4. Populate Main Description ---
         let descriptionHTML = '';
         if (item.long_description) {
-            descriptionHTML = marked.parse(item.long_description);
+            descriptionHTML = marked.parse(item.long_description.replace(/\\n/g, "\n").replace(/([^\n])\n(\d+\.)/g, "$1\n\n$2"));
         } else if (item.problem_statement) {
             descriptionHTML = `
                 <h4 class="font-semibold text-slate-800">The Challenge</h4>


### PR DESCRIPTION
Fix markdown list parsing in long_description by ensuring double newlines

Previously, markdown lists within long_description fields that only had a single newline before the list items were not recognized by `marked.parse` as lists, leading to incorrect rendering where raw asterisks were displayed instead of bold text and bullet points were absent.

This adds a preprocessing step in app.js that ensures double newlines before list items to properly parse them.

---
*PR created automatically by Jules for task [13709832021771584533](https://jules.google.com/task/13709832021771584533) started by @Qamar2315*